### PR TITLE
Fix an issue where request processing queue is stuck because of an error in the callback function execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "description": "This is a node module bundled with Node Package Manager(NPM). It is a javascript and does not require any compilation.",
-  "version": "2.0.2"
+  "version": "2.0.3"
 }

--- a/smartfilter.js
+++ b/smartfilter.js
@@ -1087,7 +1087,12 @@ function smartfilter() {
   }
 
   this.smartfilterRequest = function(m, cb) {
-    m.cb = cb;
+    // Update callback method to execute it asynchronously,
+    // So that the errors generated does not affect smartfilter and callback is not processed
+    // synchronously
+    m.cb = function(...args){
+      setTimeout(() => cb(...args), 0);
+    };
     if (m.hasOwnProperty('instanceReference') || m.type == 'connect') {
 
       myRequestStack.push(m);


### PR DESCRIPTION
To fix the issue we have changed the callback execution as a setTimeout
call which moves callback execution out of current execution call-stack of javascript
executor and will be processed when main thread is done processing current call-stack.